### PR TITLE
Updated build infrastructure files to work on macOS and VS2022

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,17 @@
 # - Added the full source code of the vecmath library as given in 2012.
 # - Build libvecmath.a to current working directory and link from there.
 # - Updated also clean target; added "veryclean" to rid of library.
-#
+# - Build on macOS requires GLUT and OpenGL as frameworks instead of libraries
+# - Removed f flag from ar call in building libvecmath.a
 .PHONY: all clean veryclean
 INCFLAGS  = -I /usr/include/GL
 INCFLAGS += -I ./vecmath/include
 
-LINKFLAGS = -lglut -lGL -lGLU
+ifeq ($(UNAME_S),Darwin)
+	LINKFLAGS = -framework GLUT -framework OpenGL
+else
+	LINKFLAGS = -lglut -lGL -lGLU
+endif
 LINKFLAGS += -L ./ -lvecmath
 
 CFLAGS    = -O2 -Wall -DSOLN

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ INCFLAGS += -I ./vecmath/include
 LINKFLAGS = -lglut -lGL -lGLU
 LINKFLAGS += -L ./ -lvecmath
 
-CFLAGS    = -O2 -Wall -ansi -DSOLN
+CFLAGS    = -O2 -Wall -DSOLN
 CC        = g++
 SRCS      = main.cpp
 OBJS      = $(SRCS:.cpp=.o)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: $(SRCS) $(PROG)
 
 libvecmath.a: $(addprefix vecmath/src/,$(VECMATHSRC))
 	g++ -c $(CFLAGS) $(INCFLAGS) $(addprefix vecmath/src/,$(VECMATHSRC))
-	ar crf $@ $(VECMATHOBJ)
+	ar cr $@ $(VECMATHOBJ)
 
 $(PROG): $(OBJS) libvecmath.a
 	$(CC) $(CFLAGS) $(OBJS) -o $@ $(LINKFLAGS)

--- a/zero.vcxproj
+++ b/zero.vcxproj
@@ -19,12 +19,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
- Korjasin makefilen toimimaan myös Macilla, ar-komennolta rikkinäinen f-lippu pois sekä GLUTin ja OpenGLn linkkaus mukaan framework-lipulla 
- Myös makefilessä otin pois ANSI-lipun, kun kuitenkin opiskelijat saa käyttää uusinta standardia (jota kääntäjä tukee), sekä Linux- että Mac-käyttäjien eduksi
- zero.vcxproj-filessä päivitin toolchainin version, niin opiskelijan ei tarvitse itse päivittää sitä projektia ekaa kertaa Visual Studiossa avatessaan.